### PR TITLE
Изменения сломанной верстки в разделителе в навбаре

### DIFF
--- a/src/component/MainNavbar.jsx
+++ b/src/component/MainNavbar.jsx
@@ -4,7 +4,7 @@ import useApp from "../hook/useApp"
 import { SidebarToggleButton } from "./Sidebar";
 
 const NavDivider = () => {
-    return <div className="nav-item py-2 py-lg-1 col-12 col-lg-auto">
+    return <div className="nav-item py-2 py-lg-1 col-lg-auto">
         <div className="vr d-none d-lg-flex h-100 mx-lg-2 text-white"></div>
         <hr className="d-lg-none my-2 text-white-50" />
     </div>


### PR DESCRIPTION
Графических изменений нет, но с этим селектором ломался навигационный бар на ширине между 768px и 992px.
На гифках можно увидеть, что на этом диапазоне ширины разделитель между кнопкой переключения тем и аватаркой игрока растягивается до неприличных размеров и ломает весь навбар

До:
![c7d3uRPK38](https://user-images.githubusercontent.com/54080214/206284486-846230ea-ec5d-4c45-bf95-81762dd78ab9.gif)

После:
![chrome_PHpaDGCYUq](https://user-images.githubusercontent.com/54080214/206284500-74be6055-3b9a-4045-9b59-982f628dec02.gif)
