### PR TITLE
Импорт в едином стиле

### DIFF
--- a/src/bootstrap.scss
+++ b/src/bootstrap.scss
@@ -10,4 +10,4 @@ $font-family-sans-serif: system-ui, "Nunito", sans-serif, "Apple Color Emoji", "
 $headings-font-family: system-ui, "Inter", sans-serif;
 $enable-negative-margins: true;
 
-@import "../node_modules/bootstrap/scss/bootstrap";
+@import '../node_modules/bootstrap/scss/bootstrap';

--- a/src/component/AppProvider.jsx
+++ b/src/component/AppProvider.jsx
@@ -21,15 +21,15 @@ function Preloader() {
 }
 
 function AuthLoadError({ error, app }) {
-    const [reloading, setReloading] = useState(false)
+    const [isReloading, setIsReloading] = useState(false)
 
     const reload = () => {
-        if (reloading) return
-        setReloading(true)
+        if (isReloading) return
+        setIsReloading(true)
         app.fetchAuth({
-            success: () => setReloading(false),
+            success: () => setIsReloading(false),
             error: () => {
-                setReloading(false)
+                setIsReloading(false)
                 Notifications.error("Ошибка осталась ヽ(ಠ_ಠ)ノ")
             },
         })
@@ -40,9 +40,9 @@ function AuthLoadError({ error, app }) {
         <h5 className='text-danger'>{error}</h5>
         <p>Если ошибка повторяется, значит что-то не работает, попробуйте зайти позже.</p>
         <div>
-            <button className='btn btn-outline-primary' onClick={reload} disabled={reloading}>
-                {reloading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
-                {reloading ? ' Пробую...' : 'Попробовать еще раз'}
+            <button className='btn btn-outline-primary' onClick={reload} disabled={isReloading}>
+                {isReloading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
+                {isReloading ? ' Пробую...' : 'Попробовать еще раз'}
             </button>
         </div>
     </div>
@@ -69,7 +69,7 @@ function AppProvider({ children }) {
             skinModified: 0,
         }
     })
-    const [loading, setLoading] = useState(!!getToken())
+    const [isLoading, setIsLoading] = useState(!!getToken())
     const [error, setError] = useState(null)
 
     const updateApp = (newVal) => {
@@ -141,8 +141,8 @@ function AppProvider({ children }) {
     useEffect(() => {
         if (getToken()) {
             fetchAuth({
-                success: () => setLoading(false),
-                error: () => setLoading(false),
+                success: () => setIsLoading(false),
+                error: () => setIsLoading(false),
             })
         }
 
@@ -164,7 +164,7 @@ function AppProvider({ children }) {
 
     const value = { app, updateApp, logout, fetchAuth }
 
-    if (loading)
+    if (isLoading)
         return <Preloader />
 
     if (error)

--- a/src/component/BalanceCard.jsx
+++ b/src/component/BalanceCard.jsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom"
-import useApp from "../hook/useApp"
-import { ruPluralizeVimers } from "../lib/i18n"
+import { Link } from 'react-router-dom'
+import useApp from '../hook/useApp'
+import { ruPluralizeVimers } from '../lib/i18n'
 
 export const BalanceCard = ({ pay }) => {
     const { app } = useApp()

--- a/src/component/ConfirmModal.jsx
+++ b/src/component/ConfirmModal.jsx
@@ -1,4 +1,4 @@
-import { Modal } from "react-bootstrap"
+import { Modal } from 'react-bootstrap'
 
 export const ConfirmModal = ({
     show, close, onCancel, onConfirm,

--- a/src/component/InnerPage.jsx
+++ b/src/component/InnerPage.jsx
@@ -1,6 +1,6 @@
-import { Outlet } from "react-router-dom"
-import MainNavbar from "./MainNavbar"
-import Sidebar from "./Sidebar"
+import { Outlet } from 'react-router-dom'
+import MainNavbar from './MainNavbar'
+import Sidebar from './Sidebar'
 
 const InnerPage = () => {
     return <>

--- a/src/component/MainNavbar.jsx
+++ b/src/component/MainNavbar.jsx
@@ -1,7 +1,7 @@
-import classNames from "classnames"
-import { Container, Nav, Navbar, NavDropdown, Offcanvas } from "react-bootstrap"
-import useApp from "../hook/useApp"
-import { SidebarToggleButton } from "./Sidebar"
+import classNames from 'classnames'
+import { Container, Nav, Navbar, NavDropdown, Offcanvas } from 'react-bootstrap'
+import useApp from '../hook/useApp'
+import { SidebarToggleButton } from './Sidebar'
 
 const NavDivider = () => {
     return <div className="nav-item py-2 py-md-1">

--- a/src/component/OuterPage.jsx
+++ b/src/component/OuterPage.jsx
@@ -1,4 +1,4 @@
-import useApp from "../hook/useApp"
+import useApp from '../hook/useApp'
 
 const OuterPage = ({ children, variant = 'blue' }) => {
     const { app } = useApp()

--- a/src/component/Pagination.jsx
+++ b/src/component/Pagination.jsx
@@ -1,4 +1,4 @@
-import { Spinner } from "react-bootstrap"
+import { Spinner } from 'react-bootstrap'
 
 const maxPages = 5 // sync with server
 

--- a/src/component/PaymentHistoryCard.jsx
+++ b/src/component/PaymentHistoryCard.jsx
@@ -1,8 +1,8 @@
-import { useEffect } from "react"
-import { Spinner } from "react-bootstrap"
-import useLoadPages from "../hook/useLoadPages"
-import { fetchApi } from "../lib/api"
-import { EventBus, EVENT_UPDATE_PAYMENTS } from "../lib/eventbus"
+import { useEffect } from 'react'
+import { Spinner } from 'react-bootstrap'
+import useLoadPages from '../hook/useLoadPages'
+import { fetchApi } from '../lib/api'
+import { EventBus, EVENT_UPDATE_PAYMENTS } from '../lib/eventbus'
 
 const paymentDescription = (p) => {
     if (p.alias.startsWith('up_'))

--- a/src/component/PromoCard.jsx
+++ b/src/component/PromoCard.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react"
-import { Form, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import useApp from "../hook/useApp"
-import useLoadPages from "../hook/useLoadPages"
-import { fetchApi } from "../lib/api"
-import Notifications from "../lib/notifications"
+import { useState } from 'react'
+import { Form, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import useApp from '../hook/useApp'
+import useLoadPages from '../hook/useLoadPages'
+import { fetchApi } from '../lib/api'
+import Notifications from '../lib/notifications'
 
 export const PromoCard = () => {
     const { fetchAuth } = useApp()

--- a/src/component/Root.jsx
+++ b/src/component/Root.jsx
@@ -1,6 +1,6 @@
-import { Navigate, Outlet, ScrollRestoration, useLocation } from "react-router-dom"
-import useApp from "../hook/useApp"
-import AppProvider from "./AppProvider"
+import { Navigate, Outlet, ScrollRestoration, useLocation } from 'react-router-dom'
+import useApp from '../hook/useApp'
+import AppProvider from './AppProvider'
 
 const pagesWithNoAuth = ['/login', '/register', '/recovery', '/recovery/step2']
 const pagesWithNoMfa = ['/login/mfa', '/login/mfa/recovery']

--- a/src/component/Sidebar.jsx
+++ b/src/component/Sidebar.jsx
@@ -1,9 +1,9 @@
-import classNames from "classnames"
-import { useEffect, useState } from "react"
+import classNames from 'classnames'
+import { useEffect, useState } from 'react'
 import { Offcanvas } from "react-bootstrap"
-import { Link, useLocation, useResolvedPath } from "react-router-dom"
-import useSharedState from "../hook/useSharedState"
-import { EventBus } from "../lib/eventbus"
+import { Link, useLocation, useResolvedPath } from 'react-router-dom'
+import useSharedState from '../hook/useSharedState'
+import { EventBus } from '../lib/eventbus'
 import './Sidebar.css'
 
 const KeyShowToggle = Symbol('sidebar.show')

--- a/src/component/skin/SkinCard.jsx
+++ b/src/component/skin/SkinCard.jsx
@@ -1,11 +1,11 @@
-import { lazy, Suspense, useEffect, useRef, useState } from "react"
-import { Button, Modal, OverlayTrigger, Spinner, Tooltip } from "react-bootstrap"
-import useApp from "../../hook/useApp"
-import { fetchApi } from "../../lib/api"
-import { EventBus, EVENT_LOGOUT } from "../../lib/eventbus"
-import Notifications from "../../lib/notifications"
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { Button, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
+import useApp from '../../hook/useApp'
+import { fetchApi } from '../../lib/api'
+import { EventBus, EVENT_LOGOUT } from '../../lib/eventbus'
+import Notifications from '../../lib/notifications'
 
-const SkinViewer3d = lazy(() => import("./SkinViewer3d"))
+const SkinViewer3d = lazy(() => import('./SkinViewer3d'))
 
 const maxSizeKb = 50
 let capeExistsCache = null
@@ -18,7 +18,7 @@ const ModalSkin = ({ show, close }) => {
     const { updateApp } = useApp()
     const file = useRef()
     const [skinType, setSkinType] = useState('steve')
-    const [loading, setLoading] = useState(false)
+    const [isLoading, setIsLoading] = useState(false)
 
     const onSubmit = e => {
         e.preventDefault()
@@ -29,7 +29,7 @@ const ModalSkin = ({ show, close }) => {
             return
         }
 
-        setLoading(true)
+        setIsLoading(true)
         const formData = new FormData()
         formData.append('file', skinFile)
         formData.append('type', skinType)
@@ -60,7 +60,7 @@ const ModalSkin = ({ show, close }) => {
                 file.current.value = null
             })
             .catch(() => Notifications.error('Невозможно подключиться к серверу'))
-            .finally(() => setLoading(false))
+            .finally(() => setIsLoading(false))
     }
 
     return <Modal show={show} onHide={close}>
@@ -108,9 +108,9 @@ const ModalSkin = ({ show, close }) => {
                 <Button variant="secondary" onClick={close}>
                     Закрыть
                 </Button>
-                <Button type="submit" variant="primary" disabled={loading}>
-                    {loading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
-                    {loading ? ' Загрузка...' : 'Изменить'}
+                <Button type="submit" variant="primary" disabled={isLoading}>
+                    {isLoading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
+                    {isLoading ? ' Загрузка...' : 'Изменить'}
                 </Button>
             </Modal.Footer>
         </form>
@@ -120,7 +120,7 @@ const ModalSkin = ({ show, close }) => {
 const ModalCape = ({ show, close, exists, onChanged }) => {
     const { fetchAuth, updateApp } = useApp()
     const file = useRef()
-    const [loading, setLoading] = useState(false)
+    const [isLoading, setIsLoading] = useState(false)
 
     const onSubmit = e => {
         e.preventDefault()
@@ -131,7 +131,7 @@ const ModalCape = ({ show, close, exists, onChanged }) => {
             return
         }
 
-        setLoading(true)
+        setIsLoading(true)
         const formData = new FormData()
         formData.append('file', skinFile)
         fetchApi('/user/cape', {
@@ -172,7 +172,7 @@ const ModalCape = ({ show, close, exists, onChanged }) => {
                 file.current.value = null
             })
             .catch(() => Notifications.error('Невозможно подключиться к серверу'))
-            .finally(() => setLoading(false))
+            .finally(() => setIsLoading(false))
     }
 
     return <Modal show={show} onHide={close}>
@@ -197,9 +197,9 @@ const ModalCape = ({ show, close, exists, onChanged }) => {
                 <Button variant="secondary" onClick={close}>
                     Закрыть
                 </Button>
-                <Button type="submit" variant="primary" disabled={loading}>
-                    {loading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
-                    {loading ? ' Загрузка...' : exists ? 'Изменить' : 'Купить'}
+                <Button type="submit" variant="primary" disabled={isLoading}>
+                    {isLoading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
+                    {isLoading ? ' Загрузка...' : exists ? 'Изменить' : 'Купить'}
                 </Button>
             </Modal.Footer>
         </form>

--- a/src/component/skin/SkinViewer3d.jsx
+++ b/src/component/skin/SkinViewer3d.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react"
-import { ErrorBoundary } from "react-error-boundary"
-import ReactSkinview3d from "react-skinview3d"
-import { IdleAnimation } from "skinview3d"
-import useApp from "../../hook/useApp"
+import { useEffect, useState } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import ReactSkinview3d from 'react-skinview3d'
+import { IdleAnimation } from 'skinview3d'
+import useApp from '../../hook/useApp'
 
 import steve from './steve.png'
 

--- a/src/hook/useApp.tsx
+++ b/src/hook/useApp.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react"
+import { createContext, useContext } from 'react'
 
 interface FetchAuthOptionsType {
     success?: () => void;

--- a/src/hook/useInvisibleRecaptcha.tsx
+++ b/src/hook/useInvisibleRecaptcha.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef } from "react"
-import ReCAPTCHA from "react-google-recaptcha"
+import { useCallback, useRef } from 'react'
+import ReCAPTCHA from 'react-google-recaptcha'
 
 function useInvisibleRecaptcha() {
     const rc = useRef<ReCAPTCHA>(null)

--- a/src/hook/useLoadPages.tsx
+++ b/src/hook/useLoadPages.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react"
-import { IdPagination } from "../component/Pagination"
+import { useEffect, useRef, useState } from 'react'
+import { IdPagination } from '../component/Pagination'
 
 interface Pagination {
     has_more: boolean;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,4 +1,4 @@
-import { EventBus, EVENT_NOTIFICATIONS_CHANGED } from "./eventbus"
+import { EventBus, EVENT_NOTIFICATIONS_CHANGED } from './eventbus'
 
 let list: any[] = []
 

--- a/src/page/AccountDelete.jsx
+++ b/src/page/AccountDelete.jsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react"
-import { Link, useNavigate, useSearchParams } from "react-router-dom"
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import Notifications from '../lib/notifications'
-import { fetchApi } from "../lib/api"
-import { Spinner } from "react-bootstrap"
-import useApp from "../hook/useApp"
-import OuterPage from "../component/OuterPage"
-import { useTitle } from "../hook/useTitle"
+import { fetchApi } from '../lib/api'
+import { Spinner } from 'react-bootstrap'
+import useApp from '../hook/useApp'
+import OuterPage from '../component/OuterPage'
+import { useTitle } from '../hook/useTitle'
 
 const DeleteInProgressFragment = ({ progress }) => {
     const { app, updateApp } = useApp()

--- a/src/page/Bans.jsx
+++ b/src/page/Bans.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "react"
-import { OverlayTrigger, Tab, Tabs, Tooltip } from "react-bootstrap"
-import { useNavigate } from "react-router-dom"
-import { ConfirmModal } from "../component/ConfirmModal"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import { ruPluralizeVimers } from "../lib/i18n"
-import Notifications from "../lib/notifications"
+import { useEffect, useState } from 'react'
+import { OverlayTrigger, Tab, Tabs, Tooltip } from 'react-bootstrap'
+import { useNavigate } from 'react-router-dom'
+import { ConfirmModal } from '../component/ConfirmModal'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import { ruPluralizeVimers } from '../lib/i18n'
+import Notifications from '../lib/notifications'
 
 const ServerBansCard = ({ name, url }) => {
     const [loading, setLoading] = useState(true)

--- a/src/page/ConfirmTransaction.jsx
+++ b/src/page/ConfirmTransaction.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "react"
-import { Spinner } from "react-bootstrap"
-import { Link, useSearchParams } from "react-router-dom"
-import OuterPage from "../component/OuterPage"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import { ruPluralizeVimers } from "../lib/i18n"
-import Notifications from "../lib/notifications"
+import { useEffect, useState } from 'react'
+import { Spinner } from 'react-bootstrap'
+import { Link, useSearchParams } from 'react-router-dom'
+import OuterPage from '../component/OuterPage'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import { ruPluralizeVimers } from '../lib/i18n'
+import Notifications from '../lib/notifications'
 
 const rowHeight = 30
 

--- a/src/page/Discord.jsx
+++ b/src/page/Discord.jsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react"
-import { Spinner } from "react-bootstrap"
-import { useSearchParams } from "react-router-dom"
-import OuterPage from "../component/OuterPage"
-import useApp from "../hook/useApp"
-import { fetchApi } from "../lib/api"
+import { useEffect, useState } from 'react'
+import { Spinner } from 'react-bootstrap'
+import { useSearchParams } from 'react-router-dom'
+import OuterPage from '../component/OuterPage'
+import useApp from '../hook/useApp'
+import { fetchApi } from '../lib/api'
 
 const CheckCode = ({ code, resetCode }) => {
     const { app } = useApp()

--- a/src/page/Home.jsx
+++ b/src/page/Home.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react"
-import { BalanceCard } from "../component/BalanceCard"
-import { PromoCard } from "../component/PromoCard"
-import SkinCard from "../component/skin/SkinCard"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
+import { useState } from 'react'
+import { BalanceCard } from '../component/BalanceCard'
+import { PromoCard } from '../component/PromoCard'
+import SkinCard from '../component/skin/SkinCard'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
 
 const PersonalInfoCard = () => {
     const { app } = useApp()

--- a/src/page/Login.jsx
+++ b/src/page/Login.jsx
@@ -1,12 +1,12 @@
-import { useState } from "react"
-import { Link } from "react-router-dom"
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import Notifications from '../lib/notifications'
-import { fetchApi, setToken } from "../lib/api"
-import { Form, Spinner } from "react-bootstrap"
-import useApp from "../hook/useApp"
-import OuterPage from "../component/OuterPage"
-import { useTitle } from "../hook/useTitle"
-import { ruPluralize } from "../lib/i18n"
+import { fetchApi, setToken } from '../lib/api'
+import { Form, Spinner } from 'react-bootstrap'
+import useApp from '../hook/useApp'
+import OuterPage from '../component/OuterPage'
+import { useTitle } from '../hook/useTitle'
+import { ruPluralize } from '../lib/i18n'
 
 const LoginPage = () => {
     useTitle('Вход в личный кабинет')

--- a/src/page/LoginMfa.jsx
+++ b/src/page/LoginMfa.jsx
@@ -1,14 +1,14 @@
-import { useState } from "react"
-import { Form, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
+import { useState } from 'react'
+import { Form, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
 import Notifications from '../lib/notifications'
-import { fetchApi } from "../lib/api"
-import useInvisibleRecaptcha from "../hook/useInvisibleRecaptcha"
-import { Link } from "react-router-dom"
-import useApp from "../hook/useApp"
-import OuterPage from "../component/OuterPage"
-import { useTitle } from "../hook/useTitle"
-import { ruPluralize } from "../lib/i18n"
+import { fetchApi } from '../lib/api'
+import useInvisibleRecaptcha from '../hook/useInvisibleRecaptcha'
+import { Link } from 'react-router-dom'
+import useApp from '../hook/useApp'
+import OuterPage from '../component/OuterPage'
+import { useTitle } from '../hook/useTitle'
+import { ruPluralize } from '../lib/i18n'
 
 export const LoginMfaRecoveryPage = () => {
     useTitle('Восстановление двухэтапной аутентификации')

--- a/src/page/MinigamesDonate.jsx
+++ b/src/page/MinigamesDonate.jsx
@@ -1,13 +1,13 @@
-import classNames from "classnames"
-import { useEffect, useState } from "react"
-import { Form, OverlayTrigger, ProgressBar, Spinner, Tooltip } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import { EventBus, EVENT_MINIGAMES_PROFILE_UPDATED } from "../lib/eventbus"
-import { ruPluralizeVimers } from "../lib/i18n"
-import Notifications from "../lib/notifications"
+import classNames from 'classnames'
+import { useEffect, useState } from 'react'
+import { Form, OverlayTrigger, ProgressBar, Spinner, Tooltip } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import { EventBus, EVENT_MINIGAMES_PROFILE_UPDATED } from '../lib/eventbus'
+import { ruPluralizeVimers } from '../lib/i18n'
+import Notifications from '../lib/notifications'
 
 const max = 5000
 const segments = [{
@@ -38,63 +38,63 @@ const segments = [{
 }]
 
 const ranks = {
-    "": {
-        name: "Игрок",
+    '': {
+        name: 'Игрок',
     },
-    "vip": {
-        name: "VIP",
+    'vip': {
+        name: 'VIP',
         rich: <b style={{ color: "#00BE00" }}>VIP</b>,
     },
-    "premium": {
-        name: "Premium",
+    'premium': {
+        name: 'Premium',
         rich: <b style={{ color: "#00DADA" }}>Premium</b>,
     },
-    "holy": {
-        name: "Holy",
+    'holy': {
+        name: 'Holy',
         rich: <b style={{ color: "#FFBA2D" }}>Holy</b>,
     },
-    "immortal": {
-        name: "Immortal",
+    'immortal': {
+        name: 'Immortal',
         rich: <b style={{ color: "#E800D5" }}>Immortal</b>,
     },
-    "moder": {
-        name: "Модератор",
+    'moder': {
+        name: 'Модератор',
         rich: <b className="text-primary">Модератор</b>,
     },
-    "warden": {
-        name: "Проверенный модератор",
+    'warden': {
+        name: 'Проверенный модератор',
         rich: <b className="text-primary">Проверенный модератор</b>,
     },
-    "chief": {
-        name: "Главный модератор",
+    'chief': {
+        name: 'Главный модератор',
         rich: <b className="text-primary">Главный модератор</b>,
     },
-    "admin": {
-        name: "Администратор",
+    'admin': {
+        name: 'Администратор',
         rich: <b className="text-danger">Администратор</b>,
     },
-    "youtube": {
-        name: "Ютубер",
+    'youtube': {
+        name: 'Ютубер',
         rich: <b className="text-danger">Ютубер</b>,
     },
-    "dev": {
-        name: "Разработчик",
+    'dev': {
+        name: 'Разработчик',
         rich: <b className="text-primary">Разработчик</b>,
     },
-    "builder": {
-        name: "Строитель",
+    'builder': {
+        name: 'Строитель',
         rich: <b className="text-success">Строитель</b>,
     },
-    "maplead": {
-        name: "Главный строитель",
+    'maplead': {
+        name: 'Главный строитель',
         rich: <b className="text-success">Главный строитель</b>,
     },
-    "srbuilder": {
-        name: "Проверенный строитель",
+    'srbuilder': {
+        name: 'Проверенный строитель',
         rich: <b className="text-success">Проверенный строитель</b>,
     },
-    "organizer": {
-        name: "Организатор",
+    'organizer': {
+        name: 'Организатор',
         rich: <b className="text-primary">Организатор</b>,
     },
 }

--- a/src/page/OauthAutrorize.jsx
+++ b/src/page/OauthAutrorize.jsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from "react"
-import { Spinner } from "react-bootstrap"
-import { useSearchParams } from "react-router-dom"
-import OuterPage from "../component/OuterPage"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import Notifications from "../lib/notifications"
+import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from 'react-bootstrap'
+import { useSearchParams } from 'react-router-dom'
+import OuterPage from '../component/OuterPage'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import Notifications from '../lib/notifications'
 
 const loadApproves = () => {
     return JSON.parse(localStorage.getItem('oauth_consent') || '{}')

--- a/src/page/Payments.jsx
+++ b/src/page/Payments.jsx
@@ -1,14 +1,14 @@
-import { Fragment, useMemo, useState } from "react"
-import { Form, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import { BalanceCard } from "../component/BalanceCard"
-import { PaymentHistoryCard } from "../component/PaymentHistoryCard"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import { EventBus, EVENT_UPDATE_PAYMENTS } from "../lib/eventbus"
-import { ruPluralizeVimers } from "../lib/i18n"
-import Notifications from "../lib/notifications"
+import { Fragment, useMemo, useState } from 'react'
+import { Form, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import { BalanceCard } from '../component/BalanceCard'
+import { PaymentHistoryCard } from '../component/PaymentHistoryCard'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import { EventBus, EVENT_UPDATE_PAYMENTS } from '../lib/eventbus'
+import { ruPluralizeVimers } from '../lib/i18n'
+import Notifications from '../lib/notifications'
 
 const TransferCard = () => {
     const { app, fetchAuth } = useApp()

--- a/src/page/Recovery.jsx
+++ b/src/page/Recovery.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from "react"
-import { Form, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import { Link, useNavigate, useSearchParams } from "react-router-dom"
-import OuterPage from "../component/OuterPage"
-import useInvisibleRecaptcha from "../hook/useInvisibleRecaptcha"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import Notifications from "../lib/notifications"
+import { useEffect, useState } from 'react'
+import { Form, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import OuterPage from '../component/OuterPage'
+import useInvisibleRecaptcha from '../hook/useInvisibleRecaptcha'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import Notifications from '../lib/notifications'
 
 const RecoveryStep2Form = ({ token, username }) => {
     const {

--- a/src/page/Register.jsx
+++ b/src/page/Register.jsx
@@ -1,12 +1,12 @@
-import { useState } from "react"
-import { Form, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import { Link } from "react-router-dom"
+import { useState } from 'react'
+import { Form, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import { Link } from 'react-router-dom'
 import Notifications from '../lib/notifications'
-import { fetchApi } from "../lib/api"
-import useInvisibleRecaptcha from "../hook/useInvisibleRecaptcha"
-import OuterPage from "../component/OuterPage"
-import { useTitle } from "../hook/useTitle"
+import { fetchApi } from '../lib/api'
+import useInvisibleRecaptcha from '../hook/useInvisibleRecaptcha'
+import OuterPage from '../component/OuterPage'
+import { useTitle } from '../hook/useTitle'
 
 const RegisterSuccessPage = () => {
     return <OuterPage>

--- a/src/page/Security.jsx
+++ b/src/page/Security.jsx
@@ -23,11 +23,11 @@ const PasswordCard = () => {
             new_password2: '',
         }
     })
-    const [loading, setLoading] = useState(false)
+    const [isLoading, setIsLoading] = useState(false)
 
     const onSubmit = data => {
-        if (loading) return
-        setLoading(true)
+        if (isLoading) return
+        setIsLoading(true)
 
         fetchApi('/settings/password', {
             method: 'POST',
@@ -58,7 +58,7 @@ const PasswordCard = () => {
                 }
             })
             .catch(() => Notifications.error('Невозможно подключиться к серверу'))
-            .finally(() => setLoading(false))
+            .finally(() => setIsLoading(false))
     }
 
     return <div className="card">
@@ -105,9 +105,9 @@ const PasswordCard = () => {
                 </Form.Group>
 
                 <div className="text-end">
-                    <button className="btn btn-primary" disabled={loading}>
-                        {loading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
-                        {loading ? ' Загрузка...' : 'Изменить'}
+                    <button className="btn btn-primary" disabled={isLoading}>
+                        {isLoading && <Spinner className="align-baseline" as="span" size="sm" aria-hidden="true" />}
+                        {isLoading ? ' Загрузка...' : 'Изменить'}
                     </button>
                 </div>
             </form>

--- a/src/page/Security.jsx
+++ b/src/page/Security.jsx
@@ -1,11 +1,11 @@
-import classNames from "classnames"
-import { useEffect, useState } from "react"
-import { Button, Form, Modal, Spinner } from "react-bootstrap"
-import { useForm } from "react-hook-form"
-import useApp from "../hook/useApp"
-import { useTitle } from "../hook/useTitle"
-import { fetchApi } from "../lib/api"
-import Notifications from "../lib/notifications"
+import classNames from 'classnames'
+import { useEffect, useState } from 'react'
+import { Button, Form, Modal, Spinner } from 'react-bootstrap'
+import { useForm } from 'react-hook-form'
+import useApp from '../hook/useApp'
+import { useTitle } from '../hook/useTitle'
+import { fetchApi } from '../lib/api'
+import Notifications from '../lib/notifications'
 
 const PasswordCard = () => {
     const {


### PR DESCRIPTION
1. Коммит [Replaced " with '](https://github.com/VimeWorld/cabinet/commit/7c02cdd8cfb18c7fe71927978d3b75b21d03c424) говорит сам за себя, но поясню: некоторые импорты были с ", а некоторые ', логичнее придерживаться единого стиля. Обычно " ставит автоимпорт (WebStorm, например).
2. Подробная информация второго коммита есть в его описании. 
3. IDE ругается на не строгое сравнение во многих файлах, возможно, следует заменить его на строгое (см. скрин). [Статья ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) на мдн по этому поводу, возможно, поможет.
![изображение](https://user-images.githubusercontent.com/67464545/211976959-992f54bb-ab68-4883-be3c-b0dc4d69044e.png)
